### PR TITLE
Package name must be the same as the class target dir

### DIFF
--- a/src/android/AboutScreen.java
+++ b/src/android/AboutScreen.java
@@ -1,4 +1,4 @@
-package com.vlara.aboutscreen;
+package com.efl.aboutscreen;
 
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CallbackContext;


### PR DESCRIPTION
This can cause problems with android build